### PR TITLE
Stop sending analytics for `oci_config::wait_until_unavailable` to bolt/puppet

### DIFF
--- a/lib/puppet/functions/oci_config/wait_until_unavailable.rb
+++ b/lib/puppet/functions/oci_config/wait_until_unavailable.rb
@@ -36,8 +36,6 @@ Puppet::Functions.create_function('oci_config::wait_until_unavailable') do
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 
-    executor.report_function_call(self.class.name)
-
     # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 


### PR DESCRIPTION
The `Bolt#Executor` method `report_function_call` is meant to report *only* the functions built in to boltlib (the plan functions that ship with Bolt). Functions defined in external modules should not report back. Instead of attempting to "allowlist" a set of boltlib functions (as this is the first time this has happened as it appears to have been copy-pasted over from boltlib) this commit simply removes that method invocation from the external module.